### PR TITLE
tests: add unit tests for AuditInterceptor with EF Core InMemory data…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <!-- Pacotes que contém somente abstrações -->
   <ItemGroup>
-    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
   </ItemGroup>
@@ -29,11 +28,12 @@
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
   </ItemGroup>
   <!-- Pacotes Pacotes específicos da camada Api -->
   <ItemGroup>
-      <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.1" />
-      <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
   </ItemGroup>
   <!-- Pacotes para testes -->
   <ItemGroup>
@@ -45,6 +45,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
     <PackageVersion Include="Moq.EntityFrameworkCore" Version="9.0.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
     <PackageVersion Include="MockQueryable.Moq" Version="7.0.3" />
   </ItemGroup>
 </Project>

--- a/src/SnackFlow.Domain/Entities/BaseEntity.cs
+++ b/src/SnackFlow.Domain/Entities/BaseEntity.cs
@@ -18,7 +18,7 @@ public abstract class BaseEntity(Guid id) : IEquatable<Guid>
 
     public Guid Id { get; } = id;
     public DateTime CreatedAt { get; } = DateTime.UtcNow;
-    public DateTime? ModifiedAt { get; private set; }
+    public DateTime? UpdatedAt { get; private set; }
     public DateTime? DeletedAt { get; private set; }
 
     #endregion
@@ -53,7 +53,7 @@ public abstract class BaseEntity(Guid id) : IEquatable<Guid>
     #region BaseEntity Methods
 
     public void UpdateEntity()
-        => ModifiedAt = DateTime.UtcNow;
+        => UpdatedAt = DateTime.UtcNow;
     
     public void DeleteEntity()
         => DeletedAt = DateTime.UtcNow;

--- a/src/SnackFlow.Infrastructure/Persistence/Mappings/CompanyMap.cs
+++ b/src/SnackFlow.Infrastructure/Persistence/Mappings/CompanyMap.cs
@@ -30,7 +30,7 @@ public class CompanyMap : IEntityTypeConfiguration<Company>
             .IsRequired();
 
         builder
-            .Property(c => c.ModifiedAt)
+            .Property(c => c.UpdatedAt)
             .HasColumnName("modified_at")
             .HasColumnType("timestamptz");
         

--- a/tests/SnackFlow.Infrastructure.Tests/Persistence/Interceptors/AuditInterceptorTest.cs
+++ b/tests/SnackFlow.Infrastructure.Tests/Persistence/Interceptors/AuditInterceptorTest.cs
@@ -1,6 +1,48 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using SnackFlow.Domain.Tests;
+using SnackFlow.Infrastructure.Persistence.Interceptors;
+
 namespace SnackFlow.Infrastructure.Tests.Persistence.Interceptors;
 
-public class AuditInterceptorTest
+public class AuditInterceptorTest : BaseTest
 {
+    private readonly AuditInterceptor _auditInterceptor;
+    private readonly TestEntity _testEntity;
+
+    public AuditInterceptorTest()
+    {
+        _auditInterceptor = new AuditInterceptor();
+        _testEntity = CreateFaker<TestEntity>()
+            .CustomInstantiator(f => new TestEntity(Guid.CreateVersion7()))
+            .RuleFor(x => x.Name, f => f.Name.FirstName())
+            .RuleFor(x => x.Age, f => f.Random.Int(10, 50))
+            .Generate();
+    }
     
+    [Fact(DisplayName = "Saving changes when entity is modified should call UpdateEntity")]
+    public void SavingChanges_WhenEntityIsModified_ShouldCallUpdateEntity()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .AddInterceptors(_auditInterceptor)
+            .Options;
+
+        using var context = new TestDbContext(options);
+        
+        context.TestEntities.Add(_testEntity);
+        context.SaveChanges();
+
+        var originalUpdatedAt = _testEntity.UpdatedAt;
+        _testEntity.Name = _faker.Person.FullName;
+
+        // Act
+        context.SaveChanges();
+
+        // Assert
+        _testEntity.UpdatedAt.Should().NotBe(originalUpdatedAt);
+        _testEntity.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
 }

--- a/tests/SnackFlow.Infrastructure.Tests/SnackFlow.Infrastructure.Tests.csproj
+++ b/tests/SnackFlow.Infrastructure.Tests/SnackFlow.Infrastructure.Tests.csproj
@@ -8,10 +8,13 @@
     <ItemGroup>
         <PackageReference Include="Bogus" />
         <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="Moq" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
+        <PackageReference Include="Moq.EntityFrameworkCore" />
+        <PackageReference Include="MockQueryable.Moq"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -23,6 +26,7 @@
         <ProjectReference Include="..\..\src\SnackFlow.Application\SnackFlow.Application.csproj" />
         <ProjectReference Include="..\..\src\SnackFlow.Domain\SnackFlow.Domain.csproj" />
         <ProjectReference Include="..\..\src\SnackFlow.Infrastructure\SnackFlow.Infrastructure.csproj" />
+        <ProjectReference Include="..\SnackFlow.Domain.Tests\SnackFlow.Domain.Tests.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/SnackFlow.Infrastructure.Tests/TestDbContext.cs
+++ b/tests/SnackFlow.Infrastructure.Tests/TestDbContext.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace SnackFlow.Infrastructure.Tests;
+
+/// <summary>
+/// Representa uma implementação específica para testes do DbContext para uso em testes unitários.
+/// Esta classe é responsável por configurar propriedades DbSet que correspondem às tabelas do banco de dados
+/// e interagir com o contexto do banco de dados subjacente durante cenários de teste.
+/// </summary>
+public class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+{
+    public DbSet<TestEntity> TestEntities { get; set; }
+    
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TestEntity>()
+            .HasKey(e => e.Id);
+
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/tests/SnackFlow.Infrastructure.Tests/TestEntity.cs
+++ b/tests/SnackFlow.Infrastructure.Tests/TestEntity.cs
@@ -1,0 +1,14 @@
+using SnackFlow.Domain.Entities;
+
+namespace SnackFlow.Infrastructure.Tests;
+
+/// <summary>
+/// Representa uma entidade de teste que estende a entidade base. Esta classe fornece propriedades específicas
+/// para cenários de dados de teste e herda funcionalidades comuns de entidade de domínio, como gerenciamento 
+/// de identificador, timestamps de criação, atualização e exclusão.
+/// </summary>
+public class TestEntity(Guid id) : BaseEntity(id)
+{
+    public string Name { get; set; } = string.Empty;
+    public int Age { get; set; }
+}


### PR DESCRIPTION
…base

- Create AuditInterceptorTest class using BaseTest foundation
- Implement test for entity modification audit functionality
- Configure TestDbContext with proper primary key mapping
- Use Bogus faker for generating realistic test data
- Test validates UpdatedAt field is populated when entity is modified
- Setup InMemory database with interceptor registration for realistic testing