### PR TITLE
Add unit tests and endpoints for authentication features

### DIFF
--- a/src/SnackFlow.Application/Features/Auths/Queries/GetAuthenticatedUser/GetAuthenticatedUserQueryResponse.cs
+++ b/src/SnackFlow.Application/Features/Auths/Queries/GetAuthenticatedUser/GetAuthenticatedUserQueryResponse.cs
@@ -2,4 +2,4 @@ using SnackFlow.Application.Abstractions.Queries;
 
 namespace SnackFlow.Application.Features.Auths.Queries.GetAuthenticatedUser;
 
-public sealed record GetAuthenticatedUserQueryResponse(string[] permissions) : IQueryResponse;
+public sealed record GetAuthenticatedUserQueryResponse(string[] Permissions) : IQueryResponse;

--- a/tests/SnackFlow.Application.Tests/Features/Auths/Commands/LoginCommandUnitTests.cs
+++ b/tests/SnackFlow.Application.Tests/Features/Auths/Commands/LoginCommandUnitTests.cs
@@ -1,0 +1,179 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SnackFlow.Application.Abstractions.Services;
+using SnackFlow.Application.DTOs;
+using SnackFlow.Application.Exceptions;
+using SnackFlow.Application.Features.Auths.Commands.Login;
+using SnackFlow.Domain.Constants;
+using SnackFlow.Domain.Tests;
+
+namespace SnackFlow.Application.Tests.Features.Auths.Commands;
+
+public sealed class LoginCommandUnitTests : BaseTest
+{
+    #region Setup
+
+    private readonly Mock<IAuthService> _mockAuthService;
+    private readonly Mock<ITokenService> _mockTokenService;
+    private readonly Mock<ILogger<LoginCommandHandler>> _mockLogger;
+    private readonly UserDetailsDTO _userDetailsTest;
+    private readonly LoginCommand _command;
+    private readonly LoginCommandHandler _handler;
+
+    public LoginCommandUnitTests()
+    {
+        _mockAuthService = new Mock<IAuthService>();
+        _mockTokenService = new Mock<ITokenService>();
+        _mockLogger = new Mock<ILogger<LoginCommandHandler>>();
+
+        _userDetailsTest = CreateFaker<UserDetailsDTO>()
+            .CustomInstantiator(f => new UserDetailsDTO(
+                Id: Guid.CreateVersion7(),
+                UserName: f.Internet.UserName(),
+                Email: f.Internet.Email(),
+                EmailConfirmed: false,
+                PhoneNumber: string.Empty,
+                SecurityStamp: f.Random.AlphaNumeric(32),
+                Roles: f.Make(2, () => f.Name.JobTitle()).ToList(),
+                Claims: [],
+                UserDomainId: Guid.CreateVersion7()
+            ));
+
+        _command = CreateFaker<LoginCommand>()
+            .CustomInstantiator(f => new LoginCommand(
+                f.Internet.Email(),
+                f.Internet.Password()
+            ));
+
+        _handler = new LoginCommandHandler(
+            _mockAuthService.Object,
+            _mockTokenService.Object,
+            _mockLogger.Object
+        );
+    }
+
+    #endregion
+
+    #region Success Tests
+
+    [Fact(DisplayName = "Should login successfully when valid credentials are provided")]
+    public async Task Handle_WhenValidCredentials_ShouldReturnSuccessResult()
+    {
+        // Arrange
+        _mockAuthService
+            .Setup(x => x.LoginAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(_userDetailsTest);
+
+        _mockTokenService
+            .Setup(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()))
+            .Returns(_faker.Random.AlphaNumeric(32));
+
+        _mockTokenService
+            .Setup(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Returns(_faker.Random.AlphaNumeric(32));
+
+        // Act
+        var result = await _handler.Handle(_command, CancellationToken.None);
+
+        // Assert
+        result.Value.Should().NotBeNull();
+        result.Value.RefreshToken.Should().NotBeNullOrEmpty();
+        result.Value.Token.Should().NotBeNullOrEmpty();
+        result.Value.UserApplicationId.Should().Be(_userDetailsTest.Id);
+        result.Value.UserDomainId.Should().Be(_userDetailsTest.UserDomainId);
+
+        _mockAuthService.Verify(x => x.LoginAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _mockTokenService.Verify(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()), Times.Once);
+        _mockTokenService.Verify(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Exception Tests
+
+    [Fact(DisplayName = "Should throw NotFoundException when user is not found")]
+    public async Task Handle_WhenUserNotFound_ShouldThrowNotFoundException()
+    {
+        // Arrange
+        _mockAuthService
+            .Setup(x => x.LoginAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new NotFoundException(ErrorMessage.NotFound.User));
+
+        // Act
+        var result = async () => await _handler.Handle(_command, CancellationToken.None);
+
+        // Assert
+        await result.Should().ThrowExactlyAsync<NotFoundException>().WithMessage(ErrorMessage.NotFound.User);
+        _mockAuthService.Verify(x => x.LoginAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _mockTokenService.Verify(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()), Times.Never);
+        _mockTokenService.Verify(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(ErrorMessage.NotFound.User)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact(DisplayName = "Should throw UnauthorizedException when password is incorrect")]
+    public async Task Handle_WhenInvalidPassword_ShouldThrowUnauthorizedException()
+    {
+        // Arrange
+        _mockAuthService
+            .Setup(x => x.LoginAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(null as UserDetailsDTO);
+
+        // Act
+        var result = async () => await _handler.Handle(_command, CancellationToken.None);
+
+        // Assert
+        await result.Should().ThrowExactlyAsync<UnauthorizedException>().WithMessage(ErrorMessage.Invalid.Password);
+        _mockAuthService.Verify(x => x.LoginAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _mockTokenService.Verify(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()), Times.Never);
+        _mockTokenService.Verify(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+        _mockLogger.Verify(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never
+        );
+    }
+    
+    [Fact(DisplayName = "Should log error and rethrow when unexpected exception occurs")]
+    public async Task Handle_WhenUnexpectedExceptionOccurs_ShouldLogErrorAndRethrow()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Database connection failed");
+        _mockAuthService
+            .Setup(x => x.LoginAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var result = async () => await _handler.Handle(_command, CancellationToken.None);
+
+        // Assert
+        await result.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage("Database connection failed");
+    
+        _mockAuthService.Verify(x => x.LoginAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        _mockTokenService.Verify(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()), Times.Never);
+        _mockTokenService.Verify(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+    
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("InvalidOperationException")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    #endregion
+}

--- a/tests/SnackFlow.Application.Tests/Features/Auths/Commands/LogoutCommandUnitTests.cs
+++ b/tests/SnackFlow.Application.Tests/Features/Auths/Commands/LogoutCommandUnitTests.cs
@@ -1,0 +1,188 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SnackFlow.Application.Abstractions.Services;
+using SnackFlow.Application.Exceptions;
+using SnackFlow.Application.Features.Auths.Commands.Logout;
+using SnackFlow.Domain.Constants;
+using SnackFlow.Domain.Tests;
+
+namespace SnackFlow.Application.Tests.Features.Auths.Commands;
+
+public sealed class LogoutCommandUnitTests : BaseTest
+{
+    #region Setup
+
+    private readonly Mock<IAuthService> _mockAuthService;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly Mock<ILogger<LogoutCommandHandler>> _mockLogger;
+    private readonly LogoutCommand _command;
+    private readonly LogoutCommandHandler _handler;
+    private readonly Guid _userId;
+
+    public LogoutCommandUnitTests()
+    {
+        _mockAuthService = new Mock<IAuthService>();
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+        _mockLogger = new Mock<ILogger<LogoutCommandHandler>>();
+        
+        _userId = Guid.CreateVersion7();
+        _command = new LogoutCommand();
+
+        _handler = new LogoutCommandHandler(
+            _mockAuthService.Object,
+            _mockCurrentUserService.Object,
+            _mockLogger.Object
+        );
+    }
+
+    #endregion
+
+    #region Success Tests
+
+    [Fact(DisplayName = "Should logout successfully when valid user is provided")]
+    public async Task Handle_WhenValidUser_ShouldReturnSuccessResult()
+    {
+        // Arrange
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Returns(_userId);
+
+        _mockAuthService
+            .Setup(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()));
+
+        // Act
+        var result = await _handler.Handle(_command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        
+        _mockCurrentUserService.Verify(x => x.GetUserId(), Times.Once);
+        _mockAuthService.Verify(x => x.UpdateSecurityStampAndGetUserAsync(_userId.ToString()), Times.Once);
+        _mockLogger.Verify(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never
+        );
+    }
+
+    #endregion
+
+    #region Exception Tests
+
+    [Fact(DisplayName = "Should throw BadRequestException when user ID is null")]
+    public async Task Handle_WhenUserIdIsNull_ShouldThrowBadRequestException()
+    {
+        // Arrange
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Returns((Guid?)null);
+
+        // Act
+        var result = async () => await _handler.Handle(_command, CancellationToken.None);
+
+        // Assert
+        await result.Should().ThrowExactlyAsync<BadRequestException>()
+            .WithMessage(ErrorMessage.Invalid.IdIsNull);
+        
+        _mockCurrentUserService.Verify(x => x.GetUserId(), Times.Once);
+        _mockAuthService.Verify(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()), Times.Never);
+        _mockLogger.Verify(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never
+        );
+    }
+
+    [Fact(DisplayName = "Should log error and rethrow when unexpected exception occurs in authService")]
+    public async Task Handle_WhenAuthServiceThrowsUnexpectedException_ShouldLogErrorAndRethrow()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Database connection failed");
+        
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Returns(_userId);
+
+        _mockAuthService
+            .Setup(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var result = async () => await _handler.Handle(_command, CancellationToken.None);
+
+        // Assert
+        await result.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage("Database connection failed");
+        
+        _mockCurrentUserService.Verify(x => x.GetUserId(), Times.Once);
+        _mockAuthService.Verify(x => x.UpdateSecurityStampAndGetUserAsync(_userId.ToString()), Times.Once);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("InvalidOperationException")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact(DisplayName = "Should log error and rethrow when unexpected exception occurs in currentUserService")]
+    public async Task Handle_WhenCurrentUserServiceThrowsUnexpectedException_ShouldLogErrorAndRethrow()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Unable to retrieve user context");
+        
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Throws(exception);
+
+        // Act
+        var result = async () => await _handler.Handle(_command, CancellationToken.None);
+
+        // Assert
+        await result.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage("Unable to retrieve user context");
+        
+        _mockCurrentUserService.Verify(x => x.GetUserId(), Times.Once);
+        _mockAuthService.Verify(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()), Times.Never);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("InvalidOperationException")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact(DisplayName = "Should call authService with correct user ID")]
+    public async Task Handle_WhenCalled_ShouldCallAuthServiceWithCorrectUserId()
+    {
+        // Arrange
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Returns(_userId);
+
+        _mockAuthService
+            .Setup(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()));
+
+        // Act
+        await _handler.Handle(_command, CancellationToken.None);
+
+        // Assert
+        _mockAuthService.Verify(
+            x => x.UpdateSecurityStampAndGetUserAsync(_userId.ToString()), 
+            Times.Once);
+    }
+
+    #endregion
+}

--- a/tests/SnackFlow.Application.Tests/Features/Auths/Queries/GetAuthenticatedUserQueryUnitTests.cs
+++ b/tests/SnackFlow.Application.Tests/Features/Auths/Queries/GetAuthenticatedUserQueryUnitTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Moq;
+using SnackFlow.Application.Abstractions.Services;
+using SnackFlow.Application.Features.Auths.Queries.GetAuthenticatedUser;
+using SnackFlow.Domain.Tests;
+
+namespace SnackFlow.Application.Tests.Features.Auths.Queries;
+
+public sealed class GetAuthenticatedUserQueryUnitTests : BaseTest
+{
+    #region Setup
+
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly GetAuthenticatedUserQuery _query;
+    private readonly GetAuthenticatedUserQueryHandler _handler;
+
+    public GetAuthenticatedUserQueryUnitTests()
+    {
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+        _query = new GetAuthenticatedUserQuery();
+
+        _handler = new GetAuthenticatedUserQueryHandler(
+            _mockCurrentUserService.Object
+        );
+    }
+
+    #endregion
+
+    #region Success Tests
+
+    [Fact(DisplayName = "Should return authenticated user with permissions successfully")]
+    public async Task Handle_WhenCalled_ShouldReturnSuccessResult()
+    {
+        // Arrange
+        var expectedPermissions = _faker.Make(3, () => _faker.Random.String2(10)).ToArray();
+        
+        _mockCurrentUserService
+            .Setup(x => x.GetPermissions())
+            .Returns(expectedPermissions);
+
+        // Act
+        var result = await _handler.Handle(_query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Permissions.Should().BeEquivalentTo(expectedPermissions);
+        
+        _mockCurrentUserService.Verify(x => x.GetPermissions(), Times.Once);
+    }
+
+    [Fact(DisplayName = "Should return empty permissions when user has no permissions")]
+    public async Task Handle_WhenUserHasNoPermissions_ShouldReturnEmptyPermissions()
+    {
+        // Arrange
+        var emptyPermissions = Array.Empty<string>();
+        
+        _mockCurrentUserService
+            .Setup(x => x.GetPermissions())
+            .Returns(emptyPermissions);
+
+        // Act
+        var result = await _handler.Handle(_query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Permissions.Should().BeEmpty();
+        
+        _mockCurrentUserService.Verify(x => x.GetPermissions(), Times.Once);
+    }
+
+    [Fact(DisplayName = "Should call currentUserService exactly once")]
+    public async Task Handle_WhenCalled_ShouldCallCurrentUserServiceOnce()
+    {
+        // Arrange
+        var permissions = _faker.Make(2, () => _faker.Random.String2(8)).ToArray();
+        
+        _mockCurrentUserService
+            .Setup(x => x.GetPermissions())
+            .Returns(permissions);
+
+        // Act
+        await _handler.Handle(_query, CancellationToken.None);
+
+        // Assert
+        _mockCurrentUserService.Verify(x => x.GetPermissions(), Times.Once);
+        _mockCurrentUserService.VerifyNoOtherCalls();
+    }
+    
+    #endregion
+}

--- a/tests/SnackFlow.Application.Tests/Features/Auths/Queries/GetRefreshTokenQueryUnitTests.cs
+++ b/tests/SnackFlow.Application.Tests/Features/Auths/Queries/GetRefreshTokenQueryUnitTests.cs
@@ -1,0 +1,248 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SnackFlow.Application.Abstractions.Services;
+using SnackFlow.Application.DTOs;
+using SnackFlow.Application.Exceptions;
+using SnackFlow.Application.Features.Auths.Queries.GetRefreshToken;
+using SnackFlow.Domain.Constants;
+using SnackFlow.Domain.Tests;
+
+namespace SnackFlow.Application.Tests.Features.Auths.Queries;
+
+public sealed class GetRefreshTokenQueryUnitTests : BaseTest
+{
+    #region Setup
+
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly Mock<IAuthService> _mockAuthService;
+    private readonly Mock<ITokenService> _mockTokenService;
+    private readonly Mock<ILogger<GetRefreshTokenQueryHandler>> _mockLogger;
+    private readonly UserDetailsDTO _userDetailsTest;
+    private readonly GetRefreshTokenQuery _query;
+    private readonly GetRefreshTokenQueryHandler _handler;
+    private readonly Guid _userId;
+
+    public GetRefreshTokenQueryUnitTests()
+    {
+        _mockCurrentUserService = new Mock<ICurrentUserService>();
+        _mockAuthService = new Mock<IAuthService>();
+        _mockTokenService = new Mock<ITokenService>();
+        _mockLogger = new Mock<ILogger<GetRefreshTokenQueryHandler>>();
+
+        _userId = Guid.CreateVersion7();
+        
+        _userDetailsTest = CreateFaker<UserDetailsDTO>()
+            .CustomInstantiator(f => new UserDetailsDTO(
+                Id: _userId,
+                UserName: f.Internet.UserName(),
+                Email: f.Internet.Email(),
+                EmailConfirmed: false,
+                PhoneNumber: string.Empty,
+                SecurityStamp: f.Random.AlphaNumeric(32),
+                Roles: f.Make(2, () => f.Name.JobTitle()).ToList(),
+                Claims: [],
+                UserDomainId: Guid.CreateVersion7()
+            ));
+
+        _query = new GetRefreshTokenQuery();
+
+        _handler = new GetRefreshTokenQueryHandler(
+            _mockCurrentUserService.Object,
+            _mockAuthService.Object,
+            _mockTokenService.Object,
+            _mockLogger.Object
+        );
+    }
+
+    #endregion
+
+    #region Success Tests
+
+    [Fact(DisplayName = "Should generate refresh token successfully when valid user is provided")]
+    public async Task Handle_WhenValidUser_ShouldReturnSuccessResult()
+    {
+        // Arrange
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Returns(_userId);
+
+        _mockAuthService
+            .Setup(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()))
+            .ReturnsAsync(_userDetailsTest);
+
+        _mockTokenService
+            .Setup(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()))
+            .Returns(_faker.Random.AlphaNumeric(32));
+
+        _mockTokenService
+            .Setup(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Returns(_faker.Random.AlphaNumeric(32));
+
+        // Act
+        var result = await _handler.Handle(_query, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Token.Should().NotBeNullOrEmpty();
+        result.Value.RefreshToken.Should().NotBeNullOrEmpty();
+        result.Value.UserApplicationId.Should().Be(_userDetailsTest.Id);
+        result.Value.UserDomainId.Should().Be(_userDetailsTest.UserDomainId);
+
+        _mockCurrentUserService.Verify(x => x.GetUserId(), Times.Once);
+        _mockAuthService.Verify(x => x.UpdateSecurityStampAndGetUserAsync(_userId.ToString()), Times.Once);
+        _mockTokenService.Verify(x => x.GenerateToken(_userDetailsTest), Times.Once);
+        _mockTokenService.Verify(x => x.GenerateRefreshToken(_userDetailsTest.Id, _userDetailsTest.SecurityStamp), Times.Once);
+        
+        _mockLogger.Verify(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never
+        );
+    }
+
+    #endregion
+
+    #region Exception Tests
+
+    [Fact(DisplayName = "Should throw UnauthorizedException when user ID is null")]
+    public async Task Handle_WhenUserIdIsNull_ShouldThrowUnauthorizedException()
+    {
+        // Arrange
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Returns((Guid?)null);
+
+        // Act
+        var result = async () => await _handler.Handle(_query, CancellationToken.None);
+
+        // Assert
+        await result.Should().ThrowExactlyAsync<UnauthorizedException>()
+            .WithMessage(ErrorMessage.Invalid.Auth);
+        
+        _mockCurrentUserService.Verify(x => x.GetUserId(), Times.Once);
+        _mockAuthService.Verify(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()), Times.Never);
+        _mockTokenService.Verify(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()), Times.Never);
+        _mockTokenService.Verify(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+        
+        _mockLogger.Verify(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never
+        );
+    }
+
+    [Fact(DisplayName = "Should log error and rethrow when unexpected exception occurs in currentUserService")]
+    public async Task Handle_WhenCurrentUserServiceThrowsUnexpectedException_ShouldLogErrorAndRethrow()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Unable to retrieve user context");
+        
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Throws(exception);
+
+        // Act
+        var result = async () => await _handler.Handle(_query, CancellationToken.None);
+
+        // Assert
+        await result.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage("Unable to retrieve user context");
+        
+        _mockCurrentUserService.Verify(x => x.GetUserId(), Times.Once);
+        _mockAuthService.Verify(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()), Times.Never);
+        _mockTokenService.Verify(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()), Times.Never);
+        _mockTokenService.Verify(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("InvalidOperationException")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact(DisplayName = "Should log error and rethrow when unexpected exception occurs in authService")]
+    public async Task Handle_WhenAuthServiceThrowsUnexpectedException_ShouldLogErrorAndRethrow()
+    {
+        // Arrange
+        var exception = new InvalidOperationException("Database connection failed");
+        
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Returns(_userId);
+
+        _mockAuthService
+            .Setup(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()))
+            .ThrowsAsync(exception);
+
+        // Act
+        var result = async () => await _handler.Handle(_query, CancellationToken.None);
+
+        // Assert
+        await result.Should().ThrowExactlyAsync<InvalidOperationException>()
+            .WithMessage("Database connection failed");
+        
+        _mockCurrentUserService.Verify(x => x.GetUserId(), Times.Once);
+        _mockAuthService.Verify(x => x.UpdateSecurityStampAndGetUserAsync(_userId.ToString()), Times.Once);
+        _mockTokenService.Verify(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()), Times.Never);
+        _mockTokenService.Verify(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+        
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("InvalidOperationException")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact(DisplayName = "Should call services with correct parameters")]
+    public async Task Handle_WhenCalled_ShouldCallServicesWithCorrectParameters()
+    {
+        // Arrange
+        _mockCurrentUserService
+            .Setup(x => x.GetUserId())
+            .Returns(_userId);
+
+        _mockAuthService
+            .Setup(x => x.UpdateSecurityStampAndGetUserAsync(It.IsAny<string>()))
+            .ReturnsAsync(_userDetailsTest);
+
+        _mockTokenService
+            .Setup(x => x.GenerateToken(It.IsAny<UserDetailsDTO>()))
+            .Returns(_faker.Random.AlphaNumeric(32));
+
+        _mockTokenService
+            .Setup(x => x.GenerateRefreshToken(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Returns(_faker.Random.AlphaNumeric(32));
+
+        // Act
+        await _handler.Handle(_query, CancellationToken.None);
+
+        // Assert
+        _mockAuthService.Verify(
+            x => x.UpdateSecurityStampAndGetUserAsync(_userId.ToString()), 
+            Times.Once);
+        
+        _mockTokenService.Verify(
+            x => x.GenerateToken(_userDetailsTest), 
+            Times.Once);
+        
+        _mockTokenService.Verify(
+            x => x.GenerateRefreshToken(_userDetailsTest.Id, _userDetailsTest.SecurityStamp), 
+            Times.Once);
+    }
+
+    #endregion
+}

--- a/tests/SnackFlow.Domain.Tests/BaseTest.cs
+++ b/tests/SnackFlow.Domain.Tests/BaseTest.cs
@@ -10,5 +10,5 @@ public abstract class BaseTest
     protected readonly Faker _faker = new();
 
     protected Faker<T> CreateFaker<T>() where T : class
-        => new Faker<T>();
+        => new();
 }


### PR DESCRIPTION
### Summary of Changes
- Implemented unit tests for key authentication features:
  - `GetAuthenticatedUserQueryUnitTests`: Validates querying authenticated users and permissions.
  - `GetRefreshTokenQueryUnitTests`: Tests for refresh token functionality and related exceptions.
  - `LoginCommandUnitTests`: Covers login logic for valid credentials and exceptions.
  - `LogoutCommandUnitTests`: Verifies logout logic and error handling.
- Fixed property naming in `GetAuthenticatedUserQueryResponse` (`permissions` -> `Permissions`).
- Simplified `Faker` instantiation in the `BaseTest` class.
- Added new endpoints for logout and refresh token functionalities.
- Updated method for resetting user's security stamp during logout.