### PR TITLE
docs: Rename project references in design patterns and coding standards

### DIFF
--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,4 +1,4 @@
-# SnackFlow - Padrões de Codificação
+# Riber - Padrões de Codificação
 
 Este documento define as convenções e padrões de código para o projeto SnackFlow.
 

--- a/docs/design-patterns.md
+++ b/docs/design-patterns.md
@@ -1,4 +1,4 @@
-﻿# 🔧 Design Patterns - SnackFlow
+﻿# 🔧 Design Patterns - Riber
 
 Este documento detalha todos os **design patterns** e **práticas arquiteturais** implementados no projeto SnackFlow, organizados conforme a estrutura atual das pastas.
 


### PR DESCRIPTION
- Updated project name in `design-patterns.md` and `coding-standards.md` from SnackFlow to Riber for consistent branding.