### PR TITLE
feat: Mudança no Result Pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Riber - Changelog
 
+## v4.0.1 - 19/10/2025
+- **BREAKING CHANGE**: Reestruturação completa da resposta de erros da API
+    - Adicionada propriedade `type` para identificar o tipo do erro
+    - Alterada propriedade `messages` (array) para `message` (string única)
+    - Adicionada propriedade `details` (objeto) para erros de validação agrupados por campo
+    - Novo formato: `{ "type": "ERROR_TYPE", "message": "...", "details": { "Field": ["error1", "error2"] } }`
+- **MELHORIA**: Erros de validação agora agrupam múltiplas mensagens por campo
+- **MELHORIA**: Formato de erros mais alinhado com padrões modernos de API (inspirado em FastEndpoints)
+
+---
+
 ## v3.0.1 - 18/10/2025
 - CORREÇÃO: Troca do pacote de versionamento da API
 - Ajuste no setup de testes da camada Api para testes de integração

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Companies>Samuel Zedec</Companies>
     <Copyright>Copyright © $([System.DateTime]::Now.Year)</Copyright>
     <Description>Sistema de gestão financeira para um lanchonete local</Description>
-    <Version>3.0.1</Version>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <!-- Repositório e Documentação -->

--- a/src/Riber.Api/Common/Api/GlobalExceptionHandler.cs
+++ b/src/Riber.Api/Common/Api/GlobalExceptionHandler.cs
@@ -19,20 +19,19 @@ public sealed class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logge
     {
         logger.LogError(exception, "Exception occurred: {ExceptionType} - {Message}", 
             exception.GetType().Name, exception.Message);
-        
-        (int statusCode, string[] messages) = exception switch
-        {
-            RequestTimeoutException timeoutEx => (timeoutEx.Code, [timeoutEx.Message]),
-            ValidationException validationEx => (ValidationException.Code, validationEx.Messages.Select(e => e.ErrorMessage).ToArray()),
-            Layer.ApplicationException applicationEx => (applicationEx.Code, [applicationEx.Message]),
-            DomainException domainEx => (StatusCodes.Status422UnprocessableEntity, [domainEx.Message]),
-            _ => (StatusCodes.Status500InternalServerError, ["Erro inesperado no servidor!"])
-        };
-        
-        await httpContext.WriteUnauthorizedResponse(
-            code: statusCode,
-            messages: messages
-        );
+    
+        (int statusCode, string message, Dictionary<string, string[]> details) = MapExceptionToError(exception);
+        await httpContext.WriteErrorResponse(statusCode, message, details);
         return true;
     }
+
+    private static (int StatusCode, string Message, Dictionary<string, string[]> Details) MapExceptionToError(Exception exception)
+        => exception switch
+        {
+            RequestTimeoutException timeoutEx => (timeoutEx.Code, timeoutEx.Message, []),
+            ValidationException validationEx => (StatusCodes.Status400BadRequest, string.Empty, validationEx.Details),
+            Layer.ApplicationException applicationEx => (applicationEx.Code, applicationEx.Message, []),
+            DomainException domainEx => (StatusCodes.Status422UnprocessableEntity, domainEx.Message, []),
+            _ => (StatusCodes.Status500InternalServerError, "Erro inesperado no servidor.", [])
+        };
 }

--- a/src/Riber.Api/Extensions/HttpContextExtension.cs
+++ b/src/Riber.Api/Extensions/HttpContextExtension.cs
@@ -13,14 +13,18 @@ public static class HttpContextExtension
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
-    public static async Task WriteUnauthorizedResponse(
+    public static async Task WriteErrorResponse(
         this HttpContext context,
         int code,
-        params string[] messages)
+        string message,
+        Dictionary<string, string[]> details)
     {
-        var jsonResponse = JsonSerializer.Serialize(
-            Result.Failure<object>(new Error(GetErrorCode(code), messages)), JsonOptions);
+        var errorType = GetErrorCode(code);
+        var response = details.Count == 0
+            ? Result.Failure<object>(new Error(errorType, message))
+            : Result.Failure<object>(new Error(errorType, details));
 
+        var jsonResponse = JsonSerializer.Serialize(response, JsonOptions);
         context.Response.StatusCode = code;
         context.Response.ContentType = "application/json";
 

--- a/src/Riber.Api/Extensions/IActionResultExtension.cs
+++ b/src/Riber.Api/Extensions/IActionResultExtension.cs
@@ -1,0 +1,12 @@
+// using Microsoft.AspNetCore.Mvc;
+// using Riber.Application.Common;
+//
+// namespace Riber.Api.Extensions;
+//
+// public static class IActionResultExtension
+// {
+//     public static IActionResult MapStatusCode<T>(this IActionResult actionResult, Result<T> result)
+//     {
+//         
+//     }
+// }

--- a/src/Riber.Api/Middlewares/SecurityStampMiddleware.cs
+++ b/src/Riber.Api/Middlewares/SecurityStampMiddleware.cs
@@ -23,9 +23,10 @@ public sealed class SecurityStampMiddleware(
         if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(tokenSecurityStamp))
         {
             logger.LogError("Valores: userId = {UserId}, securityStamp = {TokenSecurityStamp}", userId, tokenSecurityStamp);
-            await context.WriteUnauthorizedResponse(
+            await context.WriteErrorResponse(
                 StatusCodes.Status401Unauthorized,
-                "Token do usuário inválido ou mal formado."
+                "Token do usuário inválido ou mal formado.",
+                details: []
             );
             return;
         }
@@ -34,9 +35,10 @@ public sealed class SecurityStampMiddleware(
         var user = await authService.FindByIdAsync(userId);
         if (user is null || user.SecurityStamp != tokenSecurityStamp)
         {
-            await context.WriteUnauthorizedResponse(
+            await context.WriteErrorResponse(
                 code: StatusCodes.Status401Unauthorized,
-                messages: "Security stamp inválido ou usuário não encontrado."
+                message: "Security stamp inválido ou usuário não encontrado.",
+                details: []
             );
             return;
         }

--- a/src/Riber.Application/Common/Result.cs
+++ b/src/Riber.Application/Common/Result.cs
@@ -27,9 +27,17 @@ public class Result
 
     #region Static Methods
 
-    public static Result<object> Success() => new(null, true, new Error());
-    public static Result<T> Success<T>(T value) => new(value, true, new Error());
-    public static Result<T> Failure<T>(Error error) => new(default, false, error);
+    public static Result<object> Success()
+        => new(null, true, new Error());
+
+    public static Result<T> Success<T>(T value)
+        => new(value, true, new Error());
+
+    public static Result<T> Failure<T>(Error error)
+        => new(default, false, error);
+
+    public static Result<T> Failure<T>(string type, Dictionary<string, string[]> details)
+        => new(default, false, new Error(type, details));
 
     protected static Result<T> Create<T>(T? value) =>
         value is not null ? Success(value) : Failure<T>(new Error());

--- a/src/Riber.Application/Common/ValidationError.cs
+++ b/src/Riber.Application/Common/ValidationError.cs
@@ -1,3 +1,0 @@
-﻿namespace Riber.Application.Common;
-
-public sealed record ValidationError(string PropertyName, string ErrorMessage);

--- a/src/Riber.Application/Exceptions/ValidationException.cs
+++ b/src/Riber.Application/Exceptions/ValidationException.cs
@@ -3,8 +3,7 @@ using Riber.Application.Common;
 
 namespace Riber.Application.Exceptions;
 
-public sealed class ValidationException(IEnumerable<ValidationError> messages) : Exception
+public sealed class ValidationException(Dictionary<string, string[]> details) : Exception
 {
-    public IEnumerable<ValidationError> Messages => messages;
-    public static int Code => (int)HttpStatusCode.BadRequest;
+    public Dictionary<string, string[]> Details => details;
 }

--- a/src/Riber.Domain/Abstractions/Error.cs
+++ b/src/Riber.Domain/Abstractions/Error.cs
@@ -9,21 +9,29 @@ public sealed class Error
 {
     #region Properties
 
-    public string Code { get; init; } = string.Empty;
-    public string[] Messages { get; init; } = [];
+    public string Type { get; init; } = string.Empty;
+    public string Message { get; init; } = string.Empty;
+    public Dictionary<string, string[]> Details { get; set; } = [];
 
     #endregion
 
     #region Constructors
 
     [JsonConstructor]
-    public Error() {}
-    
-    public Error(string code, params string[] messages)
+    public Error() { }
+
+    public Error(string type, string message)
     {
-        Code = code;
-        Messages = messages;
+        Type = type;
+        Message = message;
     }
-    
+
+    public Error(string type, Dictionary<string, string[]> details)
+    {
+        Type = type;
+        Message = "Dados Inválidos.";
+        Details = details;
+    }
+
     #endregion
 }

--- a/tests/Riber.Api.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Riber.Api.Tests/Controllers/AuthControllerTests.cs
@@ -48,8 +48,9 @@ public sealed class AuthControllerTests(WebAppFixture webAppFixture, DatabaseFix
         loginResponse.Should().NotBeNull();
         loginResponse.IsSuccess.Should().BeFalse();
         loginResponse.Value.Should().BeNull();
-        loginResponse.Error.Code.Should().Be("NOT_FOUND");
-        loginResponse.Error.Messages.Should().HaveCountGreaterThan(0);
+        loginResponse.Error.Type.Should().Be("NOT_FOUND");
+        loginResponse.Error.Message.Should().NotBeNullOrEmpty();
+        loginResponse.Error.Details.Should().BeNullOrEmpty();
     }
     
     #endregion


### PR DESCRIPTION
Após uma análise as mensagens não de validação de campos não ficavam claras do que qual propriedade era realmente o Error, então agora foi feita uma alteração para voltar a proprieadade Details e ajustar outras, ficando mais claro a resposta da API para erros de validação